### PR TITLE
[WIP] Fix/remove auth throw

### DIFF
--- a/src/components/auth/auth.js
+++ b/src/components/auth/auth.js
@@ -34,8 +34,6 @@ class Auth {
                 success: false,
                 message: 'No token provided.'
             });
-
-            throw 'No token provided';
         }
     }
 


### PR DESCRIPTION
The authentication module should either send an HTTP response or throw an exception when an error occurs during authentication. The simplest option with the current codebase is probably to remove the throw statement.