### PR TITLE
feat/company search: Combined filtering of users based on name and company name

### DIFF
--- a/src/components/user/userAPI.js
+++ b/src/components/user/userAPI.js
@@ -31,9 +31,18 @@ class UserAPI {
             const authenticated = await this.auth.authenticate(req, res, next);
             if (authenticated) {
                 const myId = authenticated.sub;
-                if (req.query.search) {
-                    const users = await this.userController.getFilterByNameOrCompany(
-                        req.query.search,
+                if (req.query.searchName) {
+                    const users = await this.userController.getFilteredByName(
+                        req.query.searchName,
+                        myId
+                    );
+                    res.status(200).send({
+                        success: true,
+                        data: users
+                    });
+                } else if (req.query.searchNameOrCompany) {
+                    const users = await this.userController.getFilteredByNameOrCompany(
+                        req.query.searchNameOrCompany,
                         myId
                     );
                     res.status(200).send({

--- a/src/components/user/userAPI.js
+++ b/src/components/user/userAPI.js
@@ -32,7 +32,7 @@ class UserAPI {
             if (authenticated) {
                 const myId = authenticated.sub;
                 if (req.query.search) {
-                    const users = await this.userController.getFilteredOnName(
+                    const users = await this.userController.getFilterByNameOrCompany(
                         req.query.search,
                         myId
                     );

--- a/src/components/user/userController.js
+++ b/src/components/user/userController.js
@@ -41,7 +41,30 @@ class UserController {
         return userConnections;
     }
 
-    async getFilteredOnName(filter, myId) {
+    async getFilterByNameOrCompany(filter, myId) {
+        const usersByCompany = await this.employeeModel
+            .findAll({
+                include: [
+                    {
+                        model: this.userModel,
+                        required: true
+                    },
+                    {
+                        model: this.companyModel,
+                        required: true
+                    }
+                ],
+                where: { '$company.name$': { [Op.like]: '%' + filter + '%' } }
+            })
+            .then(employees => {
+                return employees.map(e => {
+                    return {
+                        name: e.company.name,
+                        ...e.user.get()
+                    };
+                });
+            });
+
         const filteredUsers = await this.userModel.findAll({
             where: {
                 [Op.and]: [

--- a/src/components/user/userController.js
+++ b/src/components/user/userController.js
@@ -42,41 +42,27 @@ class UserController {
     }
 
     async getFilterByNameOrCompany(filter, myId) {
-        const usersByCompany = await this.employeeModel
-            .findAll({
-                include: [
-                    {
-                        model: this.userModel,
-                        required: true
-                    },
-                    {
-                        model: this.companyModel,
-                        required: true
-                    }
-                ],
-                where: { '$company.name$': { [Op.like]: '%' + filter + '%' } }
-            })
-            .then(employees => {
-                return employees.map(e => {
-                    return {
-                        name: e.company.name,
-                        ...e.user.get()
-                    };
-                });
-            });
-
         const filteredUsers = await this.userModel.findAll({
             where: {
-                [Op.and]: [
-                    Sq.where(
-                        Sq.fn(
-                            'concat',
-                            Sq.col('firstName'),
-                            ' ',
-                            Sq.col('lastName')
-                        ),
-                        { [Op.like]: '%' + filter + '%' }
-                    )
+                [Op.or]: [
+                    {
+                        [Op.and]: [
+                            Sq.where(
+                                Sq.fn(
+                                    'concat',
+                                    Sq.col('firstName'),
+                                    ' ',
+                                    Sq.col('lastName')
+                                ),
+                                { [Op.like]: '%' + filter + '%' }
+                            )
+                        ]
+                    },
+                    {
+                        '$employee.company$': {
+                            [Op.like]: '%' + filter + '%'
+                        }
+                    }
                 ],
                 id: {
                     [Op.ne]: myId

--- a/src/components/user/userController.js
+++ b/src/components/user/userController.js
@@ -95,14 +95,9 @@ class UserController {
             include: [this.jobseekerModel, this.employeeModel]
         });
 
-        const userConnections = await Promise.all(
-            filteredUsers.map(async user => {
-                const connectionStatus = await this.getConnectionStatus(
-                    user.id,
-                    myId
-                );
-                return { ...user.get(), connectionStatus };
-            })
+        const userConnections = await this.mapUserConnectionStatuses(
+            filteredUsers,
+            myId
         );
 
         return userConnections;


### PR DESCRIPTION
Implements a way to search for the companies of users as well as their names.

- Splits search into two query params, with separate query methods in the controller:
  - `searchName` filters users on name only.
  - `searchNameOrCompany` filters users on their name, or their company. 

https://github.com/askbk/inmarket-frontend/pull/100 depends on this, and should be merged simultaneously.